### PR TITLE
Add Ubuntu 25.10 and 26.04 links

### DIFF
--- a/downloads/ubuntu-server.html
+++ b/downloads/ubuntu-server.html
@@ -64,7 +64,21 @@
           <p>An open-source operating system, this archive has all versions of Ubuntu Server, the official Ubuntu flavor for servers. Comes with a CLI by default.</p>
           <br />
           <h2>Downloads</h2>
-          <p>Currently there are 38 versions avaliable to download.</p>
+          <p>Currently there are 40 versions avaliable to download.</p>
+			<p>
+            Ubuntu 26.04
+            <a href="https://releases.ubuntu.com/releases/26.04/ubuntu-26.04-live-server-amd64.iso"
+              >x64 Download</a
+            >
+            <a href="https://betawiki.net/wiki/Ubuntu_26.04">Betawiki</a>
+          </p>
+			          <p>
+            Ubuntu 25.10
+            <a href="https://releases.ubuntu.com/25.10/ubuntu-25.10-live-server-amd64.iso"
+              >x64 Download</a
+            >
+            <a href="https://betawiki.net/wiki/Ubuntu_25.10">Betawiki</a>
+          </p>
           <p>
             Ubuntu 25.04
             <a href="https://releases.ubuntu.com/plucky/ubuntu-25.04-live-server-amd64.iso"

--- a/downloads/ubuntu.html
+++ b/downloads/ubuntu.html
@@ -64,7 +64,21 @@
           <p>An open-source operating system, this archive has all versions of Ubuntu Desktop (the version with the GNOME desktop), which is the main official Ubuntu flavor.</p>
           <br />
           <h2>Downloads</h2>
-          <p>Currently there are 41 versions avaliable to download.</p>
+          <p>Currently there are 43 versions avaliable to download.</p>
+			          <p>
+            Ubuntu 26.04
+            <a href="https://releases.ubuntu.com/releases/26.04/ubuntu-26.04-desktop-amd64.iso"
+              >x64 Download</a
+            >
+            <a href="https://betawiki.net/wiki/Ubuntu_26.04">Betawiki</a>
+          </p>
+			          <p>
+            Ubuntu 25.10
+            <a href="https://releases.ubuntu.com/25.10/ubuntu-25.10-desktop-amd64.iso"
+              >x64 Download</a
+            >
+            <a href="https://betawiki.net/wiki/Ubuntu_25.10">Betawiki</a>
+          </p>
           <p>
             Ubuntu 25.04
             <a href="https://releases.ubuntu.com/plucky/ubuntu-25.04-desktop-amd64.iso"


### PR DESCRIPTION
These versions have been released since the last time the pages were updated.
Both Desktop and Server pages have been updated to include the new versions.