### PR TITLE
Add Windows 7 bootlegs link to Bootlegs metapage

### DIFF
--- a/mp/bootlegs.html
+++ b/mp/bootlegs.html
@@ -72,6 +72,7 @@
           <p>This is in early development, this list will be sorted by version soon.</p>
           <ul>
             <li><a href="/downloads/11-bootlegs.html">Windows 11 Bootlegs</a></li>
+            <li><a href="/downloads/7-bootlegs.html">Windows 7 Bootlegs</a></li>
           </ul>
         </section>
 


### PR DESCRIPTION
A page exists for Windows 7 bootlegs however was not linked to in the Bootlegs metapage